### PR TITLE
Update JNLP slave version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Collection of Dockerfiles for Jenkins agents, intended for use [Kubernetes hosting](https://github.com/jenkinsci/kubernetes-plugin).
 
 ## jenkins-agent-docker
-Agent based on [jenkinsci/docker-jnlp-slave](https://github.com/jenkinsci/docker-jnlp-slave) and [library/docker](https://github.com/docker-library/docker).
+Agent based on [jenkins/docker-jnlp-slave](https://github.com/jenkinsci/docker-jnlp-slave) and [library/docker](https://github.com/docker-library/docker).
 
 Agent includes common tools and libraries to build Docker images.
 

--- a/jenkins-agent-docker.dockerfile
+++ b/jenkins-agent-docker.dockerfile
@@ -1,4 +1,4 @@
-FROM jenkinsci/jnlp-slave:3.16-1-alpine
+FROM jenkins/jnlp-slave:3.19-1-alpine
 
 USER root
 


### PR DESCRIPTION
The current agent versions [fail to restart][1] with newer Jenkins masters.

The `jenkinsci` Docker repository is depreacted and just `jenkins` should be
used instead.

[1]: https://issues.jenkins-ci.org/browse/JENKINS-50458