### PR TITLE
Fix docker image name for Ruby agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,8 @@ def MAIN_BRANCH                    = 'master'
 def DOCKER_REGISTRY_URL            = 'https://registry.hub.docker.com'
 def DOCKER_REGISTRY_CREDENTIALS_ID = '6992a9de-fab7-4932-9907-3aba4a70c4c0'
 def IMAGE_PREFIX                   = 'salemove'
+def CPU_LIMIT_PER_BUILD            = 1
+def CPU_LIMIT_TOTAL                = 6
 
 def generateTags = { version ->
   def major, minor, patch
@@ -23,7 +25,7 @@ def buildAgentImage = { agentName, minorVersion=null ->
   imageName = "${IMAGE_PREFIX}/${agentName}"
 
   ansiColor('xterm') {
-    dockerImage = docker.build(imageName, "--pull -f ${dockerFile} .")
+    dockerImage = docker.build(imageName, "--pull -f ${dockerFile} --cpu-period 100000 --cpu-quota ${CPU_LIMIT_PER_BUILD * 100000} .")
 
     if (BRANCH_NAME == MAIN_BRANCH) {
       stage("Publish ${dockerImage.imageName()}") {
@@ -40,7 +42,13 @@ def buildAgentImage = { agentName, minorVersion=null ->
 }
 
 withResultReporting(slackChannel: '#tm-engage') {
-  inDockerAgent() {
+  inDockerAgent(
+    containers: [agentContainer(
+      image: 'salemove/jenkins-agent-docker:17.12.0',
+      resourceRequestCpu: CPU_LIMIT_TOTAL.toString(),
+      resourceLimitCpu: CPU_LIMIT_TOTAL.toString()
+    )]
+  ) {
     stage('Checkout code') {
       checkout(scm)
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ def buildAgentImage = { agentName, minorVersion=null ->
     dockerImage = docker.build(imageName, "--pull -f ${dockerFile} .")
 
     if (BRANCH_NAME == MAIN_BRANCH) {
-      stage('Publish ${dockerImage.imageName()}') {
+      stage("Publish ${dockerImage.imageName()}") {
         generateTags(version).each { tag ->
           echo("Publishing docker image ${dockerImage.imageName()} with tag ${tag}")
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,15 +13,17 @@ def generateTags = { version ->
   ["${major}.${minor}", version]
 }
 
-def buildAgentImage = { agentName ->
-  def dockerfile, imageName, dockerImage, version
+def buildAgentImage = { agentName, minorVersion=null ->
+  def dockerFile, fileSuffix, imageName, dockerImage, version
 
-  version = readFile("${agentName}.version").trim()
-  dockerfile = "${agentName}.dockerfile"
+  fileSuffix = minorVersion ? "-${minorVersion}" : ""
+  version = readFile("${agentName}${fileSuffix}.version").trim()
+  dockerFile = "${agentName}${fileSuffix}.dockerfile"
+
   imageName = "${IMAGE_PREFIX}/${agentName}"
 
   ansiColor('xterm') {
-    dockerImage = docker.build(imageName, "-f ${dockerfile} .")
+    dockerImage = docker.build(imageName, "--pull -f ${dockerFile} .")
 
     if (BRANCH_NAME == MAIN_BRANCH) {
       stage('Publish ${dockerImage.imageName()}') {
@@ -51,9 +53,9 @@ withResultReporting(slackChannel: '#tm-engage') {
     parallel(
       "Node.js": { buildAgentImage('jenkins-agent-node') },
       "Python": { buildAgentImage('jenkins-agent-python') },
-      "Ruby 2.2": { buildAgentImage('jenkins-agent-ruby-2.2') },
-      "Ruby 2.4": { buildAgentImage('jenkins-agent-ruby-2.4') },
-      "Ruby 2.5": { buildAgentImage('jenkins-agent-ruby-2.5') }
+      "Ruby 2.2": { buildAgentImage('jenkins-agent-ruby', '2.2') },
+      "Ruby 2.4": { buildAgentImage('jenkins-agent-ruby', '2.4') },
+      "Ruby 2.5": { buildAgentImage('jenkins-agent-ruby', '2.5') }
     )
   }
 }


### PR DESCRIPTION
Previous version was trying to publish images like `salemove/jenkins-agent-ruby-2.2:2.2`.
Also added `--pull` to `docker build` arguments to use cache if possible
during build stage.