### PR TITLE
Backport thread stack size patch from official Ruby alpine repo

### DIFF
--- a/jenkins-agent-ruby-2.4.dockerfile
+++ b/jenkins-agent-ruby-2.4.dockerfile
@@ -57,6 +57,14 @@ RUN set -ex \
 	\
 	&& cd /usr/src/ruby \
 	\
+# https://github.com/docker-library/ruby/issues/196
+# https://bugs.ruby-lang.org/issues/14387#note-13 (patch source)
+# https://bugs.ruby-lang.org/issues/14387#note-16 ("Therefore ncopa's patch looks good for me in general." -- only breaks glibc which doesn't matter here)
+	&& wget -O 'thread-stack-fix.patch' 'https://bugs.ruby-lang.org/attachments/download/7081/0001-thread_pthread.c-make-get_main_stack-portable-on-lin.patch' \
+	&& echo '3ab628a51d92fdf0d2b5835e93564857aea73e0c1de00313864a94a6255cb645 *thread-stack-fix.patch' | sha256sum -c - \
+	&& patch -p1 -i thread-stack-fix.patch \
+	&& rm thread-stack-fix.patch \
+	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	&& { \

--- a/jenkins-agent-ruby-2.5.dockerfile
+++ b/jenkins-agent-ruby-2.5.dockerfile
@@ -57,6 +57,14 @@ RUN set -ex \
 	\
 	&& cd /usr/src/ruby \
 	\
+# https://github.com/docker-library/ruby/issues/196
+# https://bugs.ruby-lang.org/issues/14387#note-13 (patch source)
+# https://bugs.ruby-lang.org/issues/14387#note-16 ("Therefore ncopa's patch looks good for me in general." -- only breaks glibc which doesn't matter here)
+	&& wget -O 'thread-stack-fix.patch' 'https://bugs.ruby-lang.org/attachments/download/7081/0001-thread_pthread.c-make-get_main_stack-portable-on-lin.patch' \
+	&& echo '3ab628a51d92fdf0d2b5835e93564857aea73e0c1de00313864a94a6255cb645 *thread-stack-fix.patch' | sha256sum -c - \
+	&& patch -p1 -i thread-stack-fix.patch \
+	&& rm thread-stack-fix.patch \
+	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	&& { \


### PR DESCRIPTION
See https://github.com/docker-library/ruby/pull/237 for more information
about the bug and the patch.