### PR TITLE
Bring back npm to ruby build agents

### DIFF
--- a/jenkins-agent-ruby-2.2.dockerfile
+++ b/jenkins-agent-ruby-2.2.dockerfile
@@ -117,6 +117,7 @@ RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.4/ma
 
 RUN apk add --no-cache \
   nodejs \
+  nodejs-npm \
   tzdata \
   geoip-dev \
   curl \

--- a/jenkins-agent-ruby-2.4.dockerfile
+++ b/jenkins-agent-ruby-2.4.dockerfile
@@ -145,6 +145,7 @@ RUN set -ex \
 RUN apk add --no-cache \
   postgresql-client \
   nodejs \
+  nodejs-npm \
   tzdata \
   geoip-dev \
   curl

--- a/jenkins-agent-ruby-2.5.dockerfile
+++ b/jenkins-agent-ruby-2.5.dockerfile
@@ -145,6 +145,7 @@ RUN set -ex \
 RUN apk add --no-cache \
   postgresql-client \
   nodejs \
+  nodejs-npm \
   tzdata \
   geoip-dev \
   curl


### PR DESCRIPTION
All ruby agents include NodeJS. Previously, this package also included
`npm`, but it is no longer the case. This broke some of our build which
relied on `npm` existence in Ruby agents.