### PR TITLE
Update base image version for agents to 3.36-2

### DIFF
--- a/jenkins-agent-docker.dockerfile
+++ b/jenkins-agent-docker.dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jnlp-slave:3.26-1-alpine
+FROM jenkins/jnlp-slave:3.36-2-alpine
 
 USER root
 


### PR DESCRIPTION
The latest versions support establishing a connection between master and the
agents over a direct TCP connection, slightly simplifying the startup of
agents. Update the base image to support this in these agent images as well.
See https://github.com/jenkinsci/kubernetes-plugin/pull/602 for more
information.